### PR TITLE
feat: check duplicate plays within a week

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda"
+}

--- a/backend/apps/time_manage/urls.py
+++ b/backend/apps/time_manage/urls.py
@@ -35,4 +35,9 @@ urlpatterns = [
         SwapOrderView.as_view(),
         name="swaporder",
     ),
+    path(
+        "check-duplicate/",
+        CheckDuplicateMusicView.as_view(),
+        name="check-duplicate",
+    ),
 ]

--- a/backend/apps/time_manage/views.py
+++ b/backend/apps/time_manage/views.py
@@ -2,10 +2,32 @@ from rest_framework import viewsets, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 import datetime
+import re
 from django.shortcuts import get_object_or_404
 from .models import *
 from .serializers import *
 from django.db.models import Count
+
+
+_CATALOG_PATTERNS = [
+    r'Op\.?\s*\d+(?:\s*,?\s*No\.?\s*\d+)?',  # Op. 55, Op. 55 No. 1
+    r'BWV\s*\d+[a-z]?',                        # BWV 147, BWV 147a
+    r'\bD[.\s]\s*\d{3,}\b',                    # D. 960 (Schubert, ≥3 digits)
+    r'\bKV?\.?\s*\d+\b',                       # K. 550, KV 550 (Mozart)
+    r'WoO\.?\s*\d+',                           # WoO 80 (Beethoven)
+    r'\bZ\.?\s*\d+\b',                         # Z. 340 (Purcell)
+    r'HWV\s*\d+',                              # HWV 56 (Handel)
+]
+
+
+def extract_catalog_ids(title):
+    """Extract and normalize catalog identifiers from a music title."""
+    ids = set()
+    for pattern in _CATALOG_PATTERNS:
+        for match in re.finditer(pattern, title, re.IGNORECASE):
+            normalized = re.sub(r'\s+', '', match.group().lower()).rstrip('.')
+            ids.add(normalized)
+    return ids
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -289,3 +311,36 @@ class MusicByComposerViewSet(viewsets.ReadOnlyModelViewSet):
 class NewsViewSet(viewsets.ModelViewSet):
     queryset = News.objects.all()
     serializer_class = NewsSerializer
+
+
+class CheckDuplicateMusicView(APIView):
+    def get(self, request):
+        composer_name = request.query_params.get("composer_name", "")
+        title = request.query_params.get("title", "")
+        days = int(request.query_params.get("days", 7))
+
+        new_ids = extract_catalog_ids(title)
+        if not new_ids:
+            return Response({"duplicates": []})
+
+        cutoff = datetime.date.today() - datetime.timedelta(days=days)
+        candidates = (
+            TimeMusic.objects
+            .filter(music__composer__name=composer_name, time__date__gte=cutoff)
+            .select_related("music", "music__composer", "time")
+        )
+
+        duplicates = []
+        for tm in candidates:
+            existing_ids = extract_catalog_ids(tm.music.title)
+            matched = new_ids & existing_ids
+            if matched:
+                duplicates.append({
+                    "date": str(tm.time.date),
+                    "time": tm.time.time,
+                    "music_title": tm.music.title,
+                    "composer_name": tm.music.composer.name,
+                    "matched_identifiers": sorted(matched),
+                })
+
+        return Response({"duplicates": duplicates})

--- a/backend/apps/time_manage/views.py
+++ b/backend/apps/time_manage/views.py
@@ -8,15 +8,14 @@ from .models import *
 from .serializers import *
 from django.db.models import Count
 
-
 _CATALOG_PATTERNS = [
-    r'Op\.?\s*\d+(?:\s*,?\s*No\.?\s*\d+)?',  # Op. 55, Op. 55 No. 1
-    r'BWV\s*\d+[a-z]?',                        # BWV 147, BWV 147a
-    r'\bD[.\s]\s*\d{3,}\b',                    # D. 960 (Schubert, ≥3 digits)
-    r'\bKV?\.?\s*\d+\b',                       # K. 550, KV 550 (Mozart)
-    r'WoO\.?\s*\d+',                           # WoO 80 (Beethoven)
-    r'\bZ\.?\s*\d+\b',                         # Z. 340 (Purcell)
-    r'HWV\s*\d+',                              # HWV 56 (Handel)
+    r"Op\.?\s*\d+(?:\s*,?\s*No\.?\s*\d+)?",  # Op. 55, Op. 55 No. 1
+    r"BWV\s*\d+[a-z]?",  # BWV 147, BWV 147a
+    r"\bD[.\s]\s*\d{3,}\b",  # D. 960 (Schubert, ≥3 digits)
+    r"\bKV?\.?\s*\d+\b",  # K. 550, KV 550 (Mozart)
+    r"WoO\.?\s*\d+",  # WoO 80 (Beethoven)
+    r"\bZ\.?\s*\d+\b",  # Z. 340 (Purcell)
+    r"HWV\s*\d+",  # HWV 56 (Handel)
 ]
 
 
@@ -25,7 +24,7 @@ def extract_catalog_ids(title):
     ids = set()
     for pattern in _CATALOG_PATTERNS:
         for match in re.finditer(pattern, title, re.IGNORECASE):
-            normalized = re.sub(r'\s+', '', match.group().lower()).rstrip('.')
+            normalized = re.sub(r"\s+", "", match.group().lower()).rstrip(".")
             ids.add(normalized)
     return ids
 
@@ -324,23 +323,23 @@ class CheckDuplicateMusicView(APIView):
             return Response({"duplicates": []})
 
         cutoff = datetime.date.today() - datetime.timedelta(days=days)
-        candidates = (
-            TimeMusic.objects
-            .filter(music__composer__name=composer_name, time__date__gte=cutoff)
-            .select_related("music", "music__composer", "time")
-        )
+        candidates = TimeMusic.objects.filter(
+            music__composer__name=composer_name, time__date__gte=cutoff
+        ).select_related("music", "music__composer", "time")
 
         duplicates = []
         for tm in candidates:
             existing_ids = extract_catalog_ids(tm.music.title)
             matched = new_ids & existing_ids
             if matched:
-                duplicates.append({
-                    "date": str(tm.time.date),
-                    "time": tm.time.time,
-                    "music_title": tm.music.title,
-                    "composer_name": tm.music.composer.name,
-                    "matched_identifiers": sorted(matched),
-                })
+                duplicates.append(
+                    {
+                        "date": str(tm.time.date),
+                        "time": tm.time.time,
+                        "music_title": tm.music.title,
+                        "composer_name": tm.music.composer.name,
+                        "matched_identifiers": sorted(matched),
+                    }
+                )
 
         return Response({"duplicates": duplicates})

--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -19,7 +19,6 @@ from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 import apps.time_manage.routing as time_manage_routing
 
-
 application = ProtocolTypeRouter(
     {
         "http": get_asgi_application(),

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 


### PR DESCRIPTION
- 음악 제목 문자열에서 카탈로그 번호를 정규식으로 추출하고 정규화하는 extract_catalog_ids() 헬퍼 함수 추가
- GET /time_manage/check-duplicate/ 엔드포인트(CheckDuplicateMusicView) 추가 — composer_name, title, days 파라미터를 받아, 해당 기간 내에 카탈로그 번호가 겹치는 TimeMusic 레코드를 반환
- urls.py에 새 엔드포인트 등록